### PR TITLE
Change button style to absolute to prevent displacement while scrolling

### DIFF
--- a/web-app/src/components/Navigation/index.js
+++ b/web-app/src/components/Navigation/index.js
@@ -18,7 +18,7 @@ const Navigation = () => (
                 <Typography variant="h5">
                     Wisconsin Decarceration Platform
                 </Typography>
-                <Button style={{position: 'fixed', right: '2.5%', color: 'black'}} component={Link} to={ROUTES.SIGN_IN} contained="true" color="inherit"><b>Login</b></Button>
+                <Button style={{position: 'absolute', right: '2.5%', color: 'black'}} component={Link} to={ROUTES.SIGN_IN} contained="true" color="inherit"><b>Login</b></Button>
             </Toolbar>
         </AppBar>
     </div>


### PR DESCRIPTION
References #47.

Hi there! Sorry about not commenting on the issue before working on it, but I noticed this has a pretty quick fix.

"Fixed" keeps the button in place in the window regardless of scrolling. 
"Absolute" keeps the button in the same relative position w.r.t the size of the appbar.