### PR TITLE
updating icon alt text to be more descriptive

### DIFF
--- a/web-app/src/components/LandingPage/index.js
+++ b/web-app/src/components/LandingPage/index.js
@@ -16,19 +16,19 @@ const LandingPage = () => (
         <div class="icons">
             <ul>
                 <li>
-                    <img src="images/organised.png" alt="People protesting icon" />
+                    <img src="images/organised.png" alt="Redirects to sign-up sheet." />
                     <br />
                     <span>&middot;&nbsp;Get Involved&nbsp;&middot;</span>
                 </li>
                 <li>
                     <Link to={ROUTES.SERVICES}>
-                        <img src="images/help.png" alt="Helpful hand icon" />
+                        <img src="images/help.png" alt="Redirects to services that we offer." />
                     </Link>
                     <br />
                     <span>&middot;&nbsp;Get Help&nbsp;&middot;</span>
                 </li>
                 <li>
-                    <img src="images/informed.png" alt="Open book icon" />
+                    <img src="images/informed.png" alt="Redirects to our mission statement." />
                     <br />
                     <span>&middot;&nbsp;Get Informed&nbsp;&middot;</span>
                 </li>


### PR DESCRIPTION
Resolves Issue #77 

I used the following website to try and come up with a better alt text for each of the icons: https://support.siteimprove.com/hc/en-gb/articles/115000013031-Accessibility-Image-Alt-text-best-practices 

In regards to the burger button that appears for mobile users and small viewports, I think we can leave it alone because its a nav element. My understanding from this article (https://www.a11ymatters.com/pattern/mobile-nav/) is that as long as its treated as a nav element it will provide the clarity that is expected for screen readers.

100% open to requests for changes and advice, I want to learn about and support accessibility as much as possible!